### PR TITLE
Don't reveal the snakes.

### DIFF
--- a/src/server/app/round.js
+++ b/src/server/app/round.js
@@ -309,6 +309,10 @@ Round.prototype.assignRoles = function () {
             this.players[i].isSnake = false;
         }
     }
+
+    //shuffle again so that the snakes aren't
+    //  necessarily the first players
+    shuffle(this.players);
 };
 
 Round.prototype.assignNewCaptain = function () {


### PR DESCRIPTION
The player list is displayed publicly after shuffling, and the snakeCount of those first of those are always the snakes.

Note: absolutely no testing of any kind has been done on this PR.